### PR TITLE
feature: Setup domain logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.3.0] - Setup Logic Complete
+- Implemented `Setup` aggregate with full validation logic
+- Created `SetupRepository` to store setup states
+- Built `SetupService` with create and add methods
+- Added `SetupValidationException` for rule enforcement
+- Supported adding disks and controllers with checks
+- Added complete unit tests for all Setup validation logic
+- Covered disk compatibility, port limits, and controller rules
+- 
 ## [0.2.0] - CSV Parsing Layer Complete
 - Defined abstract `Hardware` class with shared fields
 - Extended `Laptop`, `Server`, `Disk`, `StorageController`

--- a/docs/diagrams/NOTES.md
+++ b/docs/diagrams/NOTES.md
@@ -15,3 +15,10 @@
 - Implement CSV loader with CsvHardwareRepository
 - Use inline unit tests for CSV parsing (no file dependency)
 
+## Sprint 3
+### Setup domain logic
+- Models the Setup entity (a build of type server or laptop)
+- Enforces valid hardware configuration rules
+- Supports attaching disks and storage controllers
+- Prep for API
+

--- a/docs/diagrams/hwshop.puml
+++ b/docs/diagrams/hwshop.puml
@@ -42,6 +42,23 @@ CsvHardwareRepository --> Disk
 CsvHardwareRepository --> StorageController
 CsvHardwareRepository ..|> HardwareRepository
 
-@enduml
+class Setup {
+  - id: long
+  - type: SetupType
+  - laptop: Laptop
+  - server: Server
+  - disks: List<Disk>
+  - controllers: List<StorageControllerWithDisks>
+}
+
+class SetupService
+class SetupRepository
+
+Setup --> Laptop
+Setup --> Server
+Setup --> Disk
+Setup --> StorageControllerWithDisks
+SetupService --> SetupRepository
+SetupService --> HardwareRepository
 
 @enduml

--- a/src/main/java/org/example/hwshop/domain/Disk.java
+++ b/src/main/java/org/example/hwshop/domain/Disk.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Disk extends Hardware {
@@ -16,4 +15,11 @@ public class Disk extends Hardware {
 
     @JsonProperty("Port")
     private String port;
+
+    public Disk(long warehouseId, String manufacturer, String model,
+                String size, String port) {
+        super(warehouseId, manufacturer, model);
+        this.size = size;
+        this.port = port;
+    }
 }

--- a/src/main/java/org/example/hwshop/domain/Laptop.java
+++ b/src/main/java/org/example/hwshop/domain/Laptop.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Laptop extends Hardware {
@@ -19,4 +18,12 @@ public class Laptop extends Hardware {
 
     @JsonProperty("Disk ports")
     private int diskPorts;
+
+    public Laptop(long warehouseId, String manufacturer, String model,
+                  String processor, String memory, int diskPorts) {
+        super(warehouseId, manufacturer, model);
+        this.processor = processor;
+        this.memory = memory;
+        this.diskPorts = diskPorts;
+    }
 }

--- a/src/main/java/org/example/hwshop/domain/Server.java
+++ b/src/main/java/org/example/hwshop/domain/Server.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Server extends Hardware {
@@ -25,4 +24,14 @@ public class Server extends Hardware {
 
     @JsonProperty("PCI-e buses")
     private int pcieBuses;
+
+    public Server(long warehouseId, String manufacturer, String model,
+                  String processor, String memory, int pciBuses, int pcixBuses, int pcieBuses) {
+        super(warehouseId, manufacturer, model);
+        this.processor = processor;
+        this.memory = memory;
+        this.pciBuses = pciBuses;
+        this.pcixBuses = pcixBuses;
+        this.pcieBuses = pcieBuses;
+    }
 }

--- a/src/main/java/org/example/hwshop/domain/Setup.java
+++ b/src/main/java/org/example/hwshop/domain/Setup.java
@@ -1,0 +1,70 @@
+package org.example.hwshop.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.hwshop.exception.SetupValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Setup {
+    private long id;
+    private SetupType type;
+
+    private Laptop laptop;
+    private Server server;
+
+    private List<Disk> disks = new ArrayList<>();
+    private List<StorageControllerWithDisks> controllers = new ArrayList<>();
+
+    public void addDisk(Disk disk) {
+        if (type == SetupType.LAPTOP) {
+            if (!"SATA".equalsIgnoreCase(disk.getPort())) {
+                throw new SetupValidationException("Laptops only support SATA disks.");
+            }
+            if (disks.size() >= laptop.getDiskPorts()) {
+                throw new SetupValidationException("Laptop has no available disk ports.");
+            }
+            disks.add(disk);
+        } else {
+            throw new SetupValidationException("Disk must be added via controller for servers.");
+        }
+    }
+
+    public void addController(StorageController controller) {
+        if (type == SetupType.LAPTOP) {
+            throw new SetupValidationException("Laptops cannot use storage controllers.");
+        }
+        if ("PCI-X".equalsIgnoreCase(controller.getBus())) {
+            throw new SetupValidationException("PCI-X controllers are not supported.");
+        }
+        controllers.add(new StorageControllerWithDisks(controller, new ArrayList<>()));
+    }
+
+    public void addDiskToController(long controllerId, Disk disk) {
+        var wrapper = controllers.stream()
+                .filter(c -> c.getController().getWarehouseId() == controllerId)
+                .findFirst()
+                .orElseThrow(() -> new SetupValidationException("Controller not found"));
+
+        StorageController ctrl = wrapper.getController();
+
+        boolean portTypeMatch =
+                "SCSI".equalsIgnoreCase(disk.getPort()) && "SCSI".equalsIgnoreCase(ctrl.getDiskPortType()) ||
+                        ("SAS".equalsIgnoreCase(disk.getPort()) || "SATA".equalsIgnoreCase(disk.getPort())) && "SAS".equalsIgnoreCase(ctrl.getDiskPortType());
+
+        if (!portTypeMatch) {
+            throw new SetupValidationException("Incompatible disk and controller port types.");
+        }
+
+        if (wrapper.getDisks().size() >= ctrl.getDiskPorts()) {
+            throw new SetupValidationException("Controller has no available ports.");
+        }
+
+        wrapper.getDisks().add(disk);
+    }
+}

--- a/src/main/java/org/example/hwshop/domain/SetupType.java
+++ b/src/main/java/org/example/hwshop/domain/SetupType.java
@@ -1,0 +1,5 @@
+package org.example.hwshop.domain;
+
+public enum SetupType {
+    LAPTOP, SERVER
+}

--- a/src/main/java/org/example/hwshop/domain/StorageController.java
+++ b/src/main/java/org/example/hwshop/domain/StorageController.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StorageController extends Hardware {
@@ -19,4 +18,12 @@ public class StorageController extends Hardware {
 
     @JsonProperty("Disk ports")
     private int diskPorts;
+
+    public StorageController(long warehouseId, String manufacturer, String model,
+                             String bus, String diskPortType, int diskPorts) {
+        super(warehouseId, manufacturer, model);
+        this.bus = bus;
+        this.diskPortType = diskPortType;
+        this.diskPorts = diskPorts;
+    }
 }

--- a/src/main/java/org/example/hwshop/domain/StorageControllerWithDisks.java
+++ b/src/main/java/org/example/hwshop/domain/StorageControllerWithDisks.java
@@ -1,0 +1,16 @@
+package org.example.hwshop.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StorageControllerWithDisks {
+    private StorageController controller;
+    private List<Disk> disks = new ArrayList<>();
+}

--- a/src/main/java/org/example/hwshop/exception/SetupValidationException.java
+++ b/src/main/java/org/example/hwshop/exception/SetupValidationException.java
@@ -1,0 +1,7 @@
+package org.example.hwshop.exception;
+
+public class SetupValidationException extends RuntimeException {
+    public SetupValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/example/hwshop/repository/SetupRepository.java
+++ b/src/main/java/org/example/hwshop/repository/SetupRepository.java
@@ -1,0 +1,31 @@
+package org.example.hwshop.repository;
+
+import org.example.hwshop.domain.Setup;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class SetupRepository {
+
+    private final AtomicLong counter = new AtomicLong(100);
+    private final Map<Long, Setup> store = new ConcurrentHashMap<>();
+
+    public Setup save(Setup setup) {
+        long id = counter.incrementAndGet();
+        setup.setId(id);
+        store.put(id, setup);
+        return setup;
+    }
+
+    public Optional<Setup> findById(long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    public void clear() {
+        store.clear();
+    }
+}

--- a/src/main/java/org/example/hwshop/service/SetupRepository.java
+++ b/src/main/java/org/example/hwshop/service/SetupRepository.java
@@ -1,0 +1,4 @@
+package org.example.hwshop.service;
+
+public class SetupRepository {
+}

--- a/src/main/java/org/example/hwshop/service/SetupService.java
+++ b/src/main/java/org/example/hwshop/service/SetupService.java
@@ -1,0 +1,4 @@
+package org.example.hwshop.service;
+
+public class SetupService {
+}

--- a/src/test/java/org/example/hwshop/domain/SetupTest.java
+++ b/src/test/java/org/example/hwshop/domain/SetupTest.java
@@ -1,0 +1,127 @@
+package org.example.hwshop.domain;
+
+import org.example.hwshop.exception.SetupValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+
+class SetupTest {
+
+    private Laptop laptop;
+    private Server server;
+    private Disk sataDisk;
+    private Disk scsiDisk;
+    private Disk sasDisk;
+
+    private StorageController sasController;
+    private StorageController scsiController;
+    private StorageController pciXController;
+
+    @BeforeEach
+    void setUp() {
+        laptop = new Laptop(1001, "Lenovo", "ThinkPad", "i7", "16G", 1);
+        server = new Server(2002, "HP", "DL380", "Xeon", "32G", 2, 2, 2);
+
+        sataDisk = new Disk(3001, "WD", "Blue", "500G", "SATA");
+        scsiDisk = new Disk(3002, "IBM", "Ultra", "18G", "SCSI");
+        sasDisk = new Disk(3003, "Seagate", "Savvio", "600G", "SAS");
+
+        sasController = new StorageController(4001, "LSI", "MegaRAID", "PCI", "SAS", 2);
+        scsiController = new StorageController(4002, "Adaptec", "SCSI123", "PCI-e", "SCSI", 1);
+        pciXController = new StorageController(4003, "HighPoint", "Unsupported", "PCI-X", "SATA", 2);
+    }
+
+    @Test
+    void laptopShouldAcceptOnlySataDisk() {
+        Setup setup = new Setup(1, SetupType.LAPTOP, laptop, null, new ArrayList<>(), new ArrayList<>());
+
+        setup.addDisk(sataDisk);
+        assertEquals(1, setup.getDisks().size());
+    }
+
+    @Test
+    void laptopShouldRejectNonSataDisk() {
+        Setup setup = new Setup(1, SetupType.LAPTOP, laptop, null, new ArrayList<>(), new ArrayList<>());
+
+        assertThrows(SetupValidationException.class, () -> setup.addDisk(scsiDisk));
+        assertThrows(SetupValidationException.class, () -> setup.addDisk(sasDisk));
+    }
+
+    @Test
+    void laptopShouldRejectMoreDisksThanPorts() {
+        laptop.setDiskPorts(1);
+        Setup setup = new Setup(1, SetupType.LAPTOP, laptop, null, new ArrayList<>(), new ArrayList<>());
+
+        setup.addDisk(sataDisk);
+        assertThrows(SetupValidationException.class, () -> setup.addDisk(new Disk(3004, "Samsung", "EVO", "1TB", "SATA")));
+    }
+
+    @Test
+    void laptopShouldRejectStorageController() {
+        Setup setup = new Setup(1, SetupType.LAPTOP, laptop, null, new ArrayList<>(), new ArrayList<>());
+
+        assertThrows(SetupValidationException.class, () -> setup.addController(sasController));
+    }
+
+    @Test
+    void serverShouldAcceptValidController() {
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+
+        setup.addController(sasController);
+        assertEquals(1, setup.getControllers().size());
+    }
+
+    @Test
+    void serverShouldRejectPciXController() {
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+
+        assertThrows(SetupValidationException.class, () -> setup.addController(pciXController));
+    }
+
+    @Test
+    void serverShouldRejectDiskWithoutController() {
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+
+        assertThrows(SetupValidationException.class, () -> setup.addDisk(sataDisk));
+    }
+
+    @Test
+    void serverShouldAddDiskToMatchingSasController() {
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+        setup.addController(sasController);
+        setup.addDiskToController(sasController.getWarehouseId(), sataDisk);
+        setup.addDiskToController(sasController.getWarehouseId(), sasDisk);
+
+        assertEquals(2, setup.getControllers().get(0).getDisks().size());
+    }
+
+    @Test
+    void serverShouldRejectSataOnScsiController() {
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+        setup.addController(scsiController);
+
+        assertThrows(SetupValidationException.class, () -> setup.addDiskToController(scsiController.getWarehouseId(), sataDisk));
+    }
+
+    @Test
+    void controllerShouldRejectTooManyDisks() {
+        StorageController singlePortCtrl = new StorageController(9000, "Mini", "TinyCtrl", "PCI", "SAS", 1);
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+
+        setup.addController(singlePortCtrl);
+        setup.addDiskToController(9000, sasDisk);
+
+        assertThrows(SetupValidationException.class, () -> setup.addDiskToController(9000, sataDisk));
+    }
+
+    @Test
+    void shouldRejectUnknownControllerId() {
+        Setup setup = new Setup(1, SetupType.SERVER, null, server, new ArrayList<>(), new ArrayList<>());
+        setup.addController(sasController);
+
+        assertThrows(SetupValidationException.class, () -> setup.addDiskToController(9999L, sataDisk));
+    }
+}


### PR DESCRIPTION
### Domain Logic Overview

**Entity: Setup**
Represents an in-progress hardware build, either a laptop or server.

| Field          | Type                                                   |
| -------------- | ------------------------------------------------------ |
| `id`           | long                                                   |
| `type`         | enum `LAPTOP` or `SERVER`                              |
| `baseHardware` | `Laptop` or `Server`                                   |
| `disks`        | List of `Disk`                                         |
| `controllers`  | List of `StorageControllerWithDisks` (for server only) |

**Class: StorageControllerWithDisks**
Wraps a controller + its connected disks

**Rules to Enforce**
| Rule                                   | Applies To    | Enforced In                |
| -------------------------------------- | ------------- | -------------------------- |
| Laptops can't use controllers          | Laptop builds | `addController(...)`       |
| Laptops can only use SATA disks        | Laptop builds | `addDisk(...)`             |
| Servers allow multiple bus types       | Server builds | `addController(...)`       |
| PCI-X controllers should be rejected   | Both          | Loader / validation        |
| SCSI disks only go on SCSI controllers | Server        | `addDiskToController(...)` |
| SATA/SAS go on SAS controller only     | Server        | `addDiskToController(...)` |

**Tests that should be writted**
| Scenario                        | Should... |
| ------------------------------- | --------- |
| Add SATA disk to laptop         | pass      |
| Add SCSI disk to laptop         | fail      |
| Add PCI-X controller to server  | fail      |
| Add SAS disk to SAS controller  | pass      |
| Add SCSI disk to SAS controller | fail      |

**Test Coverage**
| Rule                             | Test Method                                            |
| -------------------------------- | ------------------------------------------------------ |
| Laptops only support SATA        | `laptopShouldAcceptOnlySataDisk` + `RejectNonSataDisk` |
| Laptops can't use controllers    | `laptopShouldRejectStorageController`                  |
| Limit disk ports                 | `laptopShouldRejectMoreDisksThanPorts`                 |
| Servers must use controllers     | `serverShouldRejectDiskWithoutController`              |
| Controllers must not be PCI-X    | `serverShouldRejectPciXController`                     |
| SAS controller can take SAS/SATA | `serverShouldAddDiskToMatchingSasController`           |
| SCSI controller only for SCSI    | `serverShouldRejectSataOnScsiController`               |
| Controller must not overflow     | `controllerShouldRejectTooManyDisks`                   |
| Controller must exist            | `shouldRejectUnknownControllerId`                      |


